### PR TITLE
Travis CIでPHP5.3のテストをできるよう修正 / PHP7.1環境でのテスト実行を追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+
+dist: precise
 
 env:
   # plugin code


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
+ [Travic CIのUbuntuイメージの変更](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default)に対応

ref: https://github.com/EC-CUBE/ec-cube/pull/2433